### PR TITLE
fix: remove hardcoded date from runtime type check setup

### DIFF
--- a/tail_jsonl/_runtime_type_check_setup.py
+++ b/tail_jsonl/_runtime_type_check_setup.py
@@ -1,7 +1,6 @@
 """Conditionally configure runtime typechecking."""
 
 from contextlib import suppress
-from datetime import datetime, timezone
 from enum import Enum
 from os import getenv
 from warnings import filterwarnings
@@ -56,12 +55,13 @@ def configure_runtime_type_checking_mode() -> None:  # pragma: no cover
             )
 
 
-_PEP585_DATE = 2025
-if datetime.now(tz=timezone.utc).year <= _PEP585_DATE:  # pragma: no cover
-    with suppress(ImportError, ModuleNotFoundError):
-        from beartype.roar import BeartypeDecorHintPep585DeprecationWarning
+# Suppress PEP 585 deprecation warnings from beartype for backwards compatibility
+# PEP 585 (Python 3.9+) allows using list[], dict[] instead of typing.List[], typing.Dict[]
+# This warning suppression can be removed once the codebase fully migrates to PEP 585 style
+with suppress(ImportError, ModuleNotFoundError, AttributeError):  # pragma: no cover
+    from beartype.roar import BeartypeDecorHintPep585DeprecationWarning
 
-        filterwarnings(
-            'ignore',
-            category=BeartypeDecorHintPep585DeprecationWarning,
-        )
+    filterwarnings(
+        'ignore',
+        category=BeartypeDecorHintPep585DeprecationWarning,
+    )


### PR DESCRIPTION
Replace hardcoded year check (2025) with unconditional warning suppression for PEP 585 deprecation warnings.

Changes:
- Remove datetime import (no longer needed)
- Remove hardcoded _PEP585_DATE constant
- Make warning suppression unconditional (still safe with suppress())
- Add AttributeError to exception suppression for robustness
- Add clarifying comments about PEP 585 and removal timeline

Benefits:
- Fix will not break in 2026 when year > 2025
- More future-proof and maintainable
- Clearer intent through documentation
- No functional change to current behavior

PEP 585 (Python 3.9+) allows list[]/dict[] instead of typing.List[]/typing.Dict[]. The suppression can be removed when the codebase fully migrates to PEP 585 style hints.

<!-- Thanks for contributing!
  To help speed up the code review process, please provide the following information:
  - A short summary of the purpose and links to any relevant GitHub Issues
  - A brief high-level summary of what changed
  - Any additional context or screenshots that would be helpful
-->
